### PR TITLE
Add UniversalPlatform.value getter

### DIFF
--- a/lib/universal_platform.dart
+++ b/lib/universal_platform.dart
@@ -3,6 +3,8 @@ import 'src/universal_platform_locator.dart' if(dart.library.io) 'src/platform_i
 
 abstract class UniversalPlatform {
 
+  static UniversalPlatformType get value => currentUniversalPlatform;
+
   static bool get isWeb => currentUniversalPlatform == UniversalPlatformType.Web;
   static bool get isMacOS => currentUniversalPlatform == UniversalPlatformType.MacOS;
   static bool get isWindows => currentUniversalPlatform == UniversalPlatformType.Windows;


### PR DESCRIPTION
This exposes the current enum value. 

This is useful in order to, for example, switch upon the current platform: 

```dart
import 'package:universal_platform/universal_platform.dart';

void main() {
  String platformType;
  switch (UniversalPlatform.value) {
    case UniversalPlatformType.Web:
      platformType = "Web";
      break;
    case UniversalPlatformType.Android:
    case UniversalPlatformType.Fuchsia:
    case UniversalPlatformType.IOS:
      platformType = "Mobile";
      break;
    case UniversalPlatformType.Linux:
    case UniversalPlatformType.MacOS:
    case UniversalPlatformType.Windows:
      platformType = "Desktop";
      break;
  }

  print(platformType);
}
```

If you want me to add the example somehow, please let me know. 

Thanks!