### PR TITLE
Add `operatingSystem` getter

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -26,7 +26,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/universal_platform.dart
+++ b/lib/universal_platform.dart
@@ -13,6 +13,25 @@ abstract class UniversalPlatform {
   static bool get isIOS => currentUniversalPlatform == UniversalPlatformType.IOS;
   static bool get isFuchsia => currentUniversalPlatform == UniversalPlatformType.Fuchsia;
 
+  static String get operatingSystem {
+    switch (value) {
+      case UniversalPlatformType.Web:
+        return "web";
+      case UniversalPlatformType.MacOS:
+        return "macos";
+      case UniversalPlatformType.Windows:
+        return "windows";
+      case UniversalPlatformType.Linux:
+        return "linux";
+      case UniversalPlatformType.Android:
+        return "android";
+      case UniversalPlatformType.IOS:
+        return "ios";
+      case UniversalPlatformType.Fuchsia:
+        return "fuchsia";
+    }
+  }
+
 }
 
 enum UniversalPlatformType {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -2,4 +2,4 @@
 # See https://dart.dev/tools/pub/glossary#lockfile
 packages: {}
 sdks:
-  dart: ">=2.6.0-dev <3.0.0"
+  dart: ">=2.12.0-dev <3.0.0"


### PR DESCRIPTION
Add `operatingSystem` getter returning a string representation of the platform. 

Like `dart:io`'s `Platform.operatingSystem`.

Closes #14 